### PR TITLE
TAB-755: Remove line-height specification

### DIFF
--- a/themes/custom-theme/lms/static/css/courseware-chromeless.css
+++ b/themes/custom-theme/lms/static/css/courseware-chromeless.css
@@ -187,6 +187,10 @@ video {
     line-height: 1;
 }
 
+div.xblock.xblock-student_view.xblock-student_view-html.xmodule_display.xmodule_HtmlBlock.xblock-initialized p {
+    line-height: normal !important;
+}
+
 .course-wrapper .course-content .vert-mod .vert, .course-wrapper .courseware-results-wrapper .vert-mod .vert {
     border-bottom: white !important;
     margin-bottom: 15px;


### PR DESCRIPTION
# Description
Align the line-height between list items and paragraphs, within course content.

# Note
All the CSS is minified, and I changed it in place, so... The changes themselves aren't that obvious.